### PR TITLE
Resolve example.com instead of localhost

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.4
   - 2.5
   - 2.6
+  - 2.7
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/melt.gemspec
+++ b/melt.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'simplecov', '< 0.18'
   spec.add_development_dependency 'timecop'
 end

--- a/spec/melt/resolver_spec.rb
+++ b/spec/melt/resolver_spec.rb
@@ -9,19 +9,19 @@ module Melt
   RSpec.describe Resolver do
     subject { Melt::Resolver.instance }
     it 'resolves IPv4 and IPv6' do
-      expect(subject.resolv('localhost.').collect(&:to_s)).to eq(['::1', '127.0.0.1'])
+      expect(subject.resolv('example.com').collect(&:to_s)).to eq(['2606:2800:220:1:248:1893:25c8:1946', '93.184.216.34'])
     end
 
     it 'resolves IPv4 only' do
-      expect(subject.resolv('localhost.', :inet).collect(&:to_s)).to eq(['127.0.0.1'])
-      expect(subject.resolv('127.0.0.1', :inet).collect(&:to_s)).to eq(['127.0.0.1'])
-      expect(subject.resolv('::1', :inet).collect(&:to_s)).to eq([])
+      expect(subject.resolv('example.com', :inet).collect(&:to_s)).to eq(['93.184.216.34'])
+      expect(subject.resolv('93.184.216.34', :inet).collect(&:to_s)).to eq(['93.184.216.34'])
+      expect(subject.resolv('2606:2800:220:1:248:1893:25c8:1946', :inet).collect(&:to_s)).to eq([])
     end
 
     it 'resolves IPv6 only' do
-      expect(subject.resolv('localhost.', :inet6).collect(&:to_s)).to eq(['::1'])
-      expect(subject.resolv('127.0.0.1', :inet6).collect(&:to_s)).to eq([])
-      expect(subject.resolv('::1', :inet6).collect(&:to_s)).to eq(['::1'])
+      expect(subject.resolv('example.com', :inet6).collect(&:to_s)).to eq(['2606:2800:220:1:248:1893:25c8:1946'])
+      expect(subject.resolv('93.184.216.34', :inet6).collect(&:to_s)).to eq([])
+      expect(subject.resolv('2606:2800:220:1:248:1893:25c8:1946', :inet6).collect(&:to_s)).to eq(['2606:2800:220:1:248:1893:25c8:1946'])
     end
 
     it 'raises exceptions with unknown hosts' do

--- a/spec/melt/rule_factory_spec.rb
+++ b/spec/melt/rule_factory_spec.rb
@@ -153,16 +153,16 @@ module Melt
       result = []
 
       subject.ipv4 do
-        result = subject.build(to: { host: 'localhost.' })
+        result = subject.build(to: { host: 'example.com' })
       end
       expect(result.count).to eq(1)
-      expect(result[0].to[:host]).to eq(IPAddress.parse('127.0.0.1'))
+      expect(result[0].to[:host]).to eq(IPAddress.parse('93.184.216.34'))
 
       subject.ipv6 do
-        result = subject.build(to: { host: 'localhost.' })
+        result = subject.build(to: { host: 'example.com' })
       end
       expect(result.count).to eq(1)
-      expect(result[0].to[:host]).to eq(IPAddress.parse('::1'))
+      expect(result[0].to[:host]).to eq(IPAddress.parse('2606:2800:220:1:248:1893:25c8:1946'))
     end
   end
 end


### PR DESCRIPTION
The IP addresses of localhost. heavily depend on the configuration of
the local resolver, producing unreproductible and unexpected
consequences when running the test suite on Travis-CI.

On the other hand, the IPv4 and IPv6 addresses of example.com seems to
be somewhat stable.

Update the test suite to check for example.com addresses when testing
names resolution.