### PR TITLE
Rename "hosts" to "nodes"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 * Generate rules for [Netfilter](http://www.netfilter.org/) and [PF](http://www.openbsd.org/faq/pf/) (extensible);
 * IPv6 and IPv4 support;
-* Define the configuration of multiple *hosts* in a single file;
-* Define *services* as group of rules to mix-in in *hosts* rules definitions;
+* Define the configuration of multiple *nodes* in a single file;
+* Define *services* as group of rules to mix-in in *nodes* rules definitions;
 * Handle NAT & port redirection;
 
 ## Requirements
@@ -33,7 +33,7 @@ pass :in, proto: :tcp, to: { port: 80 }
 pass :in, proto: :udp, from: { host: '192.168.1.0/24', port: 123 }, to: { port: 123 }
 ~~~
 
-Rules must appear in either a *host* or *service* definition, *services* being
+Rules must appear in either a *node* or *service* definition, *services* being
 reusable blocks of related rules:
 
 ~~~ruby
@@ -50,12 +50,12 @@ service 'ssh' do
   pass :in, proto: :tcp, to: { port: 'ssh' }
 end
 
-host 'db.example.com' do
+node 'db.example.com' do
   service 'base'
   pass :in, proto: :tcp, from: { host: 'www1.example.com' }, to: { port: 'postgresql' }
 end
 
-host /www\d+.example.com/ do
+node /www\d+.example.com/ do
   service 'base'
   pass :in, proto: :tcp, to: { port: 'www' }
   pass :out, proto: :tcp, to: { host: 'db.example.com', port: 'postgresql' }
@@ -67,7 +67,7 @@ end
 Logging is handy for debugging missing rules in your firewall configuration.  An easy way to diagnose missing rules consists in setting a *pass* `policy`, and `log` both *in* and *out*:
 
 ~~~ruby
-host 'debilglos' do
+node 'debilglos' do
   policy :pass
 
   # Existing rules

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -6,12 +6,12 @@ Feature: Generate firewall rules
   Background:
     Given a file named "network.rb" with:
     """
-    host 'example.com' do
+    node 'example.com' do
       pass :in, proto: :tcp, to: { port: %w(http https) }
     end
     """
 
-  Scenario: Generate firewall rules for an OpenBSD host
+  Scenario: Generate firewall rules for an OpenBSD node
     When I successfully run `melt generate -f Pf network.rb example.com`
     Then the stdout should contain:
     """
@@ -19,7 +19,7 @@ Feature: Generate firewall rules
     pass in quick proto tcp to any port 443
     """
 
-  Scenario: Generate IPv4 firewall rules for a Linux host
+  Scenario: Generate IPv4 firewall rules for a Linux node
     When I successfully run `melt generate -f Netfilter4 network.rb example.com`
     Then the stdout should contain:
     """
@@ -27,7 +27,7 @@ Feature: Generate firewall rules
     -A INPUT -m conntrack --ctstate NEW -p tcp --dport 443 -j ACCEPT
     """
 
-  Scenario: Generate IPv6 firewall rules for a Linux host
+  Scenario: Generate IPv6 firewall rules for a Linux node
     When I successfully run `melt generate -f Netfilter6 network.rb example.com`
     Then the stdout should contain:
     """

--- a/features/puppet.feature
+++ b/features/puppet.feature
@@ -1,8 +1,8 @@
 Feature: Puppet
-  Scenario: Generate firewall rules for a host
+  Scenario: Generate firewall rules for a node
     Given a file named "network.rb" with:
     """
-    host 'example.com' do
+    node 'example.com' do
       pass :in, proto: :tcp, to: { port: %w(http https) }
     end
     """
@@ -26,7 +26,7 @@ Feature: Puppet
   Scenario: Displays firewall rule differences
     Given a file named "network.rb" with:
     """
-    host 'example.com' do
+    node 'example.com' do
       pass :in, proto: :tcp, to: { port: %w(ssh http) }
     end
     """

--- a/lib/melt/dsl.rb
+++ b/lib/melt/dsl.rb
@@ -9,13 +9,13 @@ module Melt
   #     pass :in, af: :inet, proto: :tcp, from: { host: '192.168.1.0/24' }, to: { port: 'ssh' }
   #   end
   #
-  #   host 'www' do
+  #   node 'www' do
   #     service 'ssh'
   #     pass :in, proto: :tcp, to: { port: 'http' }
   #     pass :out
   #   end
   #
-  #   host 'gw' do
+  #   node 'gw' do
   #     service 'ssh'
   #     pass :out, on: 'ppp0', nat_to: 'public-ip'
   #     pass :in, on: 'ppp0', proto: :tcp, to: { port: 'http' }, rdr_to: { host: 'www' }
@@ -48,11 +48,11 @@ module Melt
       @default_policy = @policy
     end
 
-    # Returns the found hosts hostname.
+    # Returns the found nodes hostname.
     #
     # @return [Array]
-    def hosts
-      @hosts.keys
+    def nodes
+      @nodes.keys
     end
 
     # Returns the found services.
@@ -133,18 +133,18 @@ module Melt
     #     pass :out, proto: :tcp, to: { host: 'backup', port: 'bacula-sd' }
     #   end
     #
-    #   host 'backup' do
+    #   node 'backup' do
     #     service 'base-services'
     #     pass :in,  proto: :tcp, to: { port: 'bacula-sd' }
     #     pass :out, proto: :tcp, from: { port: 'bacula-dir' }
     #   end
     #
-    #   host 'dns' do
+    #   node 'dns' do
     #     service 'base-services'
     #     pass :in, proto: :udp, to: { port: 'domain' }
     #   end
     #
-    #   host 'www' do
+    #   node 'www' do
     #     service 'base-services'
     #     pass :in, proto: :tcp, to: { port: 'http' }
     #   end
@@ -167,11 +167,11 @@ module Melt
     #       pass proto: :tcp, to { port: %w(http https) }
     #     end
     #
-    #     host /^node\d+/ do
+    #     node /^node\d+/ do
     #       client 'http'
     #     end
     #
-    #     host /^node\d+/ do
+    #     node /^node\d+/ do
     #       client 'http', to: { host: 'restricted-destination.example.com' }
     #     end
     #
@@ -183,7 +183,7 @@ module Melt
     #       pass proto: :tcp, to { port: 'ssh' }
     #     end
     #
-    #     host /^node\d+/ do
+    #     node /^node\d+/ do
     #       server 'ssh'
     #     end
     #
@@ -198,35 +198,35 @@ module Melt
       end
     end
 
-    # Defines rules for the host +hostname+.
+    # Defines rules for the node +hostname+.
     #
-    #   host 'fqdn' do
+    #   node 'fqdn' do
     #     pass :out
     #     pass :in, to: { port: 'ssh' }
     #   end
     #
     # @return [void]
-    def host(*hostnames, &block)
+    def node(*hostnames, &block)
       hostnames.each do |hostname|
         hostname = /\A#{hostname}\z/ if hostname.is_a?(Regexp)
-        @hosts[hostname] = block
+        @nodes[hostname] = block
       end
     end
 
     private
 
     def bloc_for(hostname)
-      @hosts[hostname] || block_matching(hostname)
+      @nodes[hostname] || block_matching(hostname)
     end
 
     def block_matching(hostname)
       found = nil
-      @hosts.select { |host, _block| host.is_a?(Regexp) }.each do |_host, block|
-        raise "Multiple host definition match \"#{hostname}\"" if found
+      @nodes.select { |node, _block| node.is_a?(Regexp) }.each do |_node, block|
+        raise "Multiple node definition match \"#{hostname}\"" if found
 
         found = block
       end
-      raise "No host definition match \"#{hostname}\"" unless found
+      raise "No node definition match \"#{hostname}\"" unless found
 
       found
     end
@@ -246,7 +246,7 @@ module Melt
 
     def reset_network
       @services = {}
-      @hosts = {}
+      @nodes = {}
     end
   end
 end

--- a/lib/melt/puppet.rb
+++ b/lib/melt/puppet.rb
@@ -3,12 +3,12 @@
 require 'fileutils'
 
 module Melt
-  # Manage hosts rulesets as a tree of rules to serve via Puppet
+  # Manage nodes rulesets as a tree of rules to serve via Puppet
   class Puppet
     # Setup an environment to store firewall rules to disk
     #
     # @param path [String] Root directory of the tree of firewall rules
-    # @param dsl [Melt::Dsl] Description of hosts and rules as a Melt::Dsl
+    # @param dsl [Melt::Dsl] Description of nodes and rules as a Melt::Dsl
     def initialize(path, dsl)
       @path = path
       @dsl = dsl
@@ -52,7 +52,7 @@ module Melt
     private
 
     def each_fragment
-      @dsl.hosts.each do |host|
+      @dsl.nodes.each do |host|
         rules = @dsl.ruleset_for(host)
         policy = @dsl.policy_for(host)
 

--- a/spec/fixtures/basic_host.rb
+++ b/spec/fixtures/basic_host.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-host 'example.com' do
+node 'example.com' do
   block :in
   pass :out
 end

--- a/spec/fixtures/hosting_network.rb
+++ b/spec/fixtures/hosting_network.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-host(/db\d+.example.com/) do
+node(/db\d+.example.com/) do
   pass :in, proto: :tcp, from: { host: '192.168.0.0/24' }, to: { port: 'postgresql' }
 end
 
-host 'db1.example.com' do
+node 'db1.example.com' do
   pass :in, proto: :tcp, from: { host: '192.168.0.0/24' }, to: { port: 'postgresql' }
   block :in, proto: :tcp, to: { port: 'mysql' }
 end

--- a/spec/fixtures/incompatible_ip_restrictions.rb
+++ b/spec/fixtures/incompatible_ip_restrictions.rb
@@ -2,7 +2,7 @@
 
 server = ['192.0.2.1', '2001:DB8::1']
 
-host 'client' do
+node 'client' do
   ipv4 do
     ipv6 do
       pass :out, on: 'eth0', proto: :tcp, to: { host: server, port: 3000 }

--- a/spec/fixtures/ip_restrictions.rb
+++ b/spec/fixtures/ip_restrictions.rb
@@ -2,7 +2,7 @@
 
 server = ['192.0.2.1', '2001:DB8::1']
 
-host 'client' do
+node 'client' do
   pass :out, on: 'eth0', proto: :tcp, to: { host: server, port: 3000 }
   ipv4 do
     pass :out, on: 'eth0', proto: :tcp, to: { host: server, port: 3001 }

--- a/spec/fixtures/multiple_hosts.rb
+++ b/spec/fixtures/multiple_hosts.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-host 'example.com', 'example.net' do
+node 'example.com', 'example.net' do
   pass :in, proto: :tcp, to: { port: 'postgresql' }
 end

--- a/spec/fixtures/policies.rb
+++ b/spec/fixtures/policies.rb
@@ -2,19 +2,19 @@
 
 policy :pass
 
-host 'www1' do
+node 'www1' do
   policy :block
 end
 
-host 'www2' do
+node 'www2' do
   policy :pass
 end
 
-host(/db\d+/) do
+node(/db\d+/) do
   policy :block
 end
 
-host 'log' do
+node 'log' do
   # Empty
 end
 

--- a/spec/fixtures/services.rb
+++ b/spec/fixtures/services.rb
@@ -8,22 +8,22 @@ service :ssh do
   pass :in, proto: 'tcp', to: { port: 'ssh' }
 end
 
-host 'server.example.com' do
+node 'server.example.com' do
   server :openvpn
 end
 
-host 'client.example.com' do
+node 'client.example.com' do
   client :openvpn
 end
 
-host 'restricted.client.example.com' do
+node 'restricted.client.example.com' do
   client :openvpn, to: { host: '10.0.0.1' }
 end
 
-host 'invalid.client1.example.com' do
+node 'invalid.client1.example.com' do
   service :openvpn
 end
 
-host 'invalid.client2.example.com' do
+node 'invalid.client2.example.com' do
   server :ssh
 end

--- a/spec/fixtures/simple_lan_network.rb
+++ b/spec/fixtures/simple_lan_network.rb
@@ -6,13 +6,13 @@ service :dns do
   pass :out, proto: :udp, to: { host: dns_servers, port: 'domain' }
 end
 
-host 'gw' do
+node 'gw' do
   service :dns
   pass :out, on: 'ppp0', nat_to: '198.51.100.72'
   pass :in, on: 'ppp0', proto: :tcp, to: { port: 'http' }, rdr_to: { host: '192.168.1.80' }
 end
 
-host 'www' do
+node 'www' do
   service :dns
   pass :in, proto: :tcp, to: { port: 'http' }
 end

--- a/spec/fixtures/trivial_network.rb
+++ b/spec/fixtures/trivial_network.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-host 'localhost' do
+node 'localhost' do
   pass :out, proto: :udp, to: { host: ['192.0.2.27'], port: 'domain' }
   pass :in, proto: :tcp, to: { port: 'ssh' }
 end

--- a/spec/fixtures/undefined_service.rb
+++ b/spec/fixtures/undefined_service.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-host 'localhost' do
+node 'localhost' do
   service 'unknown'
 end

--- a/spec/melt/dsl_spec.rb
+++ b/spec/melt/dsl_spec.rb
@@ -10,13 +10,13 @@ module Melt
       expect { subject.ruleset_for('localhost') }.to raise_error('Undefined service "unknown"')
     end
 
-    it 'detects services and hosts' do
+    it 'detects services and nodes' do
       subject.eval_network(File.join('spec', 'fixtures', 'trivial_network.rb'))
-      expect(subject.hosts).to eq(['localhost'])
+      expect(subject.nodes).to eq(['localhost'])
       expect(subject.services).to eq([])
 
       subject.eval_network(File.join('spec', 'fixtures', 'simple_lan_network.rb'))
-      expect(subject.hosts).to eq(%w[gw www])
+      expect(subject.nodes).to eq(%w[gw www])
       expect(subject.services).to eq([:dns])
     end
 


### PR DESCRIPTION
Using the same taxonomy for two different concepts is confusing.  We
have two hosts concepts:
  - An endpoint for communication, as an hostname or an IP address for a
    remote host for example;
  - An entity which hold a set of firewall rules for a given computer.

Rename the latter "node" to match the name using in Puppet and improve
the situation.
