### PR TITLE
Replace the Ruby DSL with a LALR parser

### DIFF
--- a/lib/core_ext.rb
+++ b/lib/core_ext.rb
@@ -47,4 +47,16 @@ end
 
 class Hash # :nodoc:
   include Expandable
+
+  def deep_dup
+    hash = dup
+    each_pair do |key, value|
+      if value.respond_to?(:deep_dup)
+        hash[key.dup] = value.deep_dup
+      else
+        hash[key.dup] = value.dup
+      end
+    end
+    hash
+  end
 end

--- a/lib/melt/dsl.rb
+++ b/lib/melt/dsl.rb
@@ -106,6 +106,7 @@ module Melt
         direction = build_direction(args.first)
         options[:action] = action
         options[:dir] = direction
+        options.freeze
         @rules += @factory.build(options)
       end
     end

--- a/lib/melt/rule_factory.rb
+++ b/lib/melt/rule_factory.rb
@@ -34,7 +34,7 @@ module Melt
     def build(options = {})
       return [] if options == {}
 
-      options = expand_endpoints(options)
+      options = expand_endpoints(options.deep_dup)
 
       options = { action: nil, return: false, dir: nil, af: nil, proto: nil, on: nil, from: { host: nil, port: nil }, to: { host: nil, port: nil }, nat_to: nil, rdr_to: { host: nil, port: nil } }.merge(options)
 


### PR DESCRIPTION
Writing firewall rules with a Ruby DSL is (a bit) convenient compared to writing the rules in various firewall configuration syntax, but still a perfect PITA when you don't think in Ruby.

Implement a LALR parser which supports a pf-based inspired syntax:

```
node 'foo' do
  pass :in, proto: :tcp, from: { host: '192.168.0.0/24' } to: { port: 80 }
end
```

becomes:

```pf
node 'foo' do
  pass in proto tcp from 192.168.0.0/24 to port 80
end
```